### PR TITLE
ci: fix missing schema

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,4 +20,5 @@ registries:
   terraform-opentofu:
     type: "terraform-registry"
     url: "https://registry.opentofu.org"
+    token: ""
     replaces-base: true


### PR DESCRIPTION
Add missing schema `registries.*.token` to dependabot config.