### PR TITLE
ci: remove non-allowed schema

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,4 +21,3 @@ registries:
     type: "terraform-registry"
     url: "https://registry.opentofu.org"
     token: ""
-    replaces-base: true


### PR DESCRIPTION
Remove non-allowed schema `registries.*.replaces-base` in dependabot config.