### PR TITLE
chore(deps): bump lightsail container dependency `cloudflare/cloudflared` to `2025.8.0`

### DIFF
--- a/services/ap.third-branches.net/main.tf
+++ b/services/ap.third-branches.net/main.tf
@@ -76,7 +76,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial" {
   }
   container {
     container_name = "tunnel"
-    image = "cloudflare/cloudflared:2025.7.0"
+    image = "cloudflare/cloudflared:2025.8.0"
     command = ["tunnel", "run"]
     environment = {
       SERVICE_CON = "service://localhost"


### PR DESCRIPTION
Bump AWS Lightsail container dependency `cloudflare/cloudflared` to `2025.8.0`.
Release Note: <https://github.com/cloudflare/cloudflared/releases/tag/2025.8.0>