### PR TITLE
chore(deps): bump lightsail container dependency `superseriousbusiness/gotosocial` to `0.19.2`

### DIFF
--- a/services/ap.third-branches.net/main.tf
+++ b/services/ap.third-branches.net/main.tf
@@ -52,7 +52,7 @@ resource "aws_lightsail_container_service_deployment_version" "gotosocial" {
 
   container {
     container_name = "app"
-    image = "superseriousbusiness/gotosocial:0.19.1"
+    image = "superseriousbusiness/gotosocial:0.19.2"
     environment = {
       SERVICE_CON = "service://localhost"
       TZ = "Asia/Tokyo"


### PR DESCRIPTION
Bump AWS Lightsail container dependency`superseriousbusiness/gotosocial`to `0.19.2`.
Release Note: <https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v0.19.2>